### PR TITLE
Adding codespaces support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    "name": "scala-sbt-codespaces-template",
+    //https://hub.docker.com/r/sbtscala/scala-sbt/tags
+    "image": "sbtscala/scala-sbt:eclipse-temurin-jammy-21.0.2_13_1.10.2_3.5.0",
+    "customizations": {
+      "vscode": {
+        "extensions": [
+          // Scala
+          "scala-lang.scala",
+          "scalameta.metals"
+        ]
+      }
+    },
+    "remoteUser": "sbtuser"
+  }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /.bsp/
 /.idea/
 /target/
-/project/target/
-/project/project/
+/project*/
+/.bloop/
+/.metals/
+/.vscode/


### PR DESCRIPTION
The book provides a way to run the repository example in local but it implies that you have the scala setup as a prerrequsite. For non Scala users, it could a barrier. In order to reduce the onboarding time, Cloud IDEs like Codespaces, it should be a good feature for newbie people.